### PR TITLE
Fix "TV Penetration" capitalization in media-election-2019 legend

### DIFF
--- a/public/featured/media-election-2019/main.js
+++ b/public/featured/media-election-2019/main.js
@@ -379,12 +379,15 @@ function drawTimeline(targetId = 'chart-timeline', legendId = 'legend-timeline')
 
   // Legend
   const leg = document.getElementById(legendId);
-  if (leg) leg.innerHTML = series.map(k => `
+  if (leg) leg.innerHTML = series.map(k => {
+    const label = k === 'tv' ? 'TV' : k.charAt(0).toUpperCase() + k.slice(1);
+    return `
     <div class="legend-item">
       <div class="legend-swatch" style="background:${colors[k]};height:${k === 'internet' ? '3px' : '2px'}"></div>
-      <span>${k.charAt(0).toUpperCase() + k.slice(1)} Penetration</span>
+      <span>${label} Penetration</span>
     </div>
-  `).join('');
+  `
+  }).join('');
 }
 
 // ═══════════════════════════════════════════


### PR DESCRIPTION
The legend for the "TV Penetration" series in the first visualization of the media-election-2019 page was incorrectly displayed as "Tv Penetration". This change updates the legend generation logic to special-case "TV" to ensure correct capitalization.

---
*PR created automatically by Jules for task [17403221800354635288](https://jules.google.com/task/17403221800354635288) started by @alharkan7*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only string formatting change limited to legend rendering with no data, auth, or behavioral impact beyond label text.
> 
> **Overview**
> Fixes the timeline chart legend on `public/featured/media-election-2019/main.js` to render the `tv` series label as **`TV`** (so it shows “TV Penetration” instead of “Tv Penetration”).
> 
> This updates legend HTML generation to compute a `label` per series key with a `tv` special-case while keeping other series title-cased as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4d11b2a4bc6bda8b085416060e4d288ff80f55a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->