### PR TITLE
Implement pagination for /data page

### DIFF
--- a/astro_dev.log
+++ b/astro_dev.log
@@ -1,0 +1,35 @@
+npm warn Unknown project config "shamefully-hoist". This will stop working in the next major version of npm.
+
+> raihankalla.id@1.0.0 dev
+> astro dev
+
+11:09:54 [types] Generated 1ms
+11:09:54 [content] Syncing content
+11:09:54 [content] Synced content
+
+ astro  v5.16.6 ready in 1398 ms
+
+┃ Local    http://localhost:4321/
+┃ Network  use --host to expose
+
+11:09:54 watching for file changes...
+11:10:16 [WARN] [vite] Failed to load source map for /app/node_modules/.pnpm/astro@5.16.6_@types+node@25.0.3_@vercel+functions@2.2.13_jiti@1.21.7_rollup@4.54.0_typescript@5.9.3_yaml@2.8.2/node_modules/astro/dist/vite-plugin-astro/index.js.
+SyntaxError: Unexpected token '', "��z��" is not valid JSON
+11:10:19 [200] /data 3173ms
+11:10:20 [200] /data/2 36ms
+11:10:20 [200] /data/2 22ms
+11:10:20 [200] /data/2 22ms
+11:10:54 [200] /data 30ms
+11:10:55 [200] /data/2 28ms
+11:10:55 [200] /data/2 24ms
+11:10:56 [200] /data/2 34ms
+11:11:51 [200] /data 36ms
+11:11:51 [200] /data/2 22ms
+11:11:51 [200] /data/2 21ms
+11:11:51 [200] /data/2 23ms
+11:11:52 [200] /BRIN-Quantitative-Analysis 67ms
+11:12:35 [200] /data 24ms
+11:12:36 [200] /data/2 29ms
+11:12:36 [200] /data/2 24ms
+11:12:36 [200] /data/2 21ms
+11:12:37 [200] /BRIN-Quantitative-Analysis 51ms

--- a/src/pages/data/[page].astro
+++ b/src/pages/data/[page].astro
@@ -1,16 +1,38 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
-import { featuredProjects } from "../data/featured";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { featuredProjects } from "../../data/featured";
 
+export const prerender = true;
+
+export async function getStaticPaths() {
+  const projectsPerPage = 10;
+  const totalPages = Math.ceil(featuredProjects.length / projectsPerPage);
+
+  // Generate paths for pages 2 onwards (page 1 is handled by index.astro)
+  return Array.from({ length: totalPages - 1 }, (_, i) => {
+    const page = i + 2; // Start from page 2
+    const startIndex = (page - 1) * projectsPerPage;
+    return {
+      params: { page: String(page) },
+      props: {
+        projects: featuredProjects.slice(startIndex, startIndex + projectsPerPage),
+        currentPage: page,
+        totalPages,
+      },
+    };
+  });
+}
+
+const { projects, currentPage, totalPages } = Astro.props;
 const title = "Research I did for fun";
 const description = "I scrape, analyze or visualize data in my spare time. Here's the list of special pages showcasing the results that don't fit the blog formatting.";
-const permalink = Astro.site?.href;
+const permalink = `${Astro.site?.href}data`;
 ---
 
 <BaseLayout
   title={title}
   description={description}
-  permalink={permalink ?? "/"}
+  permalink={permalink}
   current="data"
 >
   <div class="container">
@@ -18,21 +40,21 @@ const permalink = Astro.site?.href;
       <h1>{title}</h1>
       <p class="description">{description}</p>
     </header>
-    
+
     <div class="data-grid">
-      {featuredProjects.map((project) => (
-        <a 
-          href={project.url} 
-          class="data-card" 
-          target={project.url.startsWith("http") ? "_blank" : "_self"} 
+      {projects.map((project) => (
+        <a
+          href={project.url}
+          class="data-card"
+          target={project.url.startsWith("http") ? "_blank" : "_self"}
           rel={project.url.startsWith("http") ? "noopener noreferrer" : ""}
         >
           <div class="card-image-wrapper">
-            <img 
-              src={project.coverImage} 
-              alt={project.title} 
+            <img
+              src={project.coverImage}
+              alt={project.title}
               loading="lazy"
-              class="card-image" 
+              class="card-image"
             />
           </div>
           <div class="card-content">
@@ -41,6 +63,20 @@ const permalink = Astro.site?.href;
           </div>
         </a>
       ))}
+    </div>
+
+    <div class="pagination">
+      <a
+        href={currentPage === 2 ? "/data" : `/data/${currentPage - 1}`}
+        class="prev-button">← Prev</a
+      >
+      {
+        currentPage < totalPages && (
+          <a href={`/data/${currentPage + 1}`} class="next-button">
+            Next →
+          </a>
+        )
+      }
     </div>
   </div>
 
@@ -143,8 +179,45 @@ const permalink = Astro.site?.href;
       h1 {
         font-size: 2rem;
       }
-      
+    }
 
+    .pagination {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 0;
+    }
+
+    .prev-button,
+    .next-button {
+      color: var(--text-secondary);
+      transition: all 0.2s ease;
+      font-family: var(--font-family-sans);
+      font-size: 1.2em;
+      font-weight: 700;
+      text-decoration: none;
+      box-shadow: inset 0 -0.12em 0 var(--primary-color);
+      -webkit-transition:
+        box-shadow 0.2s ease-in-out,
+        color 0.2s ease-in-out;
+      transition:
+        box-shadow 0.2s ease-in-out,
+        color 0.2s ease-in-out;
+    }
+
+    .prev-button:hover,
+    .next-button:hover {
+      color: var(--primary-color);
+      box-shadow: inset 0 -1.5em 0 var(--primary-color);
+      color: #fff;
+    }
+
+    .next-button {
+      margin-left: auto;
+    }
+
+    .prev-button {
+      margin-right: auto;
     }
   </style>
 </BaseLayout>

--- a/src/pages/data/index.astro
+++ b/src/pages/data/index.astro
@@ -1,0 +1,192 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { featuredProjects } from "../../data/featured";
+
+const projectsPerPage = 10;
+const totalPages = Math.ceil(featuredProjects.length / projectsPerPage);
+const projects = featuredProjects.slice(0, projectsPerPage);
+
+const title = "Research I did for fun";
+const description = "I scrape, analyze or visualize data in my spare time. Here's the list of special pages showcasing the results that don't fit the blog formatting.";
+const permalink = Astro.site?.href;
+---
+
+<BaseLayout
+  title={title}
+  description={description}
+  permalink={permalink ?? "/"}
+  current="data"
+>
+  <div class="container">
+    <header class="page-header">
+      <h1>{title}</h1>
+      <p class="description">{description}</p>
+    </header>
+    
+    <div class="data-grid">
+      {projects.map((project) => (
+        <a 
+          href={project.url} 
+          class="data-card" 
+          target={project.url.startsWith("http") ? "_blank" : "_self"} 
+          rel={project.url.startsWith("http") ? "noopener noreferrer" : ""}
+        >
+          <div class="card-image-wrapper">
+            <img 
+              src={project.coverImage} 
+              alt={project.title} 
+              loading="lazy"
+              class="card-image" 
+            />
+          </div>
+          <div class="card-content">
+            <h3 class="card-title">{project.title}</h3>
+            {project.subtitle && <p class="card-subtitle">{project.subtitle}</p>}
+          </div>
+        </a>
+      ))}
+    </div>
+
+    <div class="pagination">
+      {
+        totalPages > 1 && (
+          <a href="/data/2" class="next-button">
+            Next →
+          </a>
+        )
+      }
+    </div>
+  </div>
+
+  <style>
+    .page-header {
+      margin-bottom: 3rem;
+      /* max-width: 800px; */
+    }
+
+    h1 {
+      margin-bottom: 1rem;
+      font-size: 2.5rem;
+      font-weight: 800;
+      letter-spacing: -0.02em;
+    }
+
+    .description {
+      font-size: 1.1rem;
+      color: var(--text-secondary);
+      line-height: 1.6;
+      /* max-width: 600px; */
+    }
+
+    .data-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+      gap: 2rem;
+      margin-bottom: 4rem;
+    }
+
+    .data-card {
+      display: flex;
+      flex-direction: column;
+      text-decoration: none;
+      color: inherit;
+      background: var(--background-elevated, rgba(255, 255, 255, 0.05));
+      border-radius: 12px;
+      overflow: hidden;
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      border: 1px solid var(--border-color, rgba(0, 0, 0, 0.1));
+      height: 100%;
+    }
+
+    .data-card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+      border-color: var(--primary-color);
+    }
+
+    .card-image-wrapper {
+      position: relative;
+      aspect-ratio: 16 / 9;
+      overflow: hidden;
+      background-color: var(--background-secondary, #f5f5f5);
+    }
+
+    .card-image {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .data-card:hover .card-image {
+      transform: scale(1.05);
+    }
+
+
+
+    .card-content {
+      padding: 1.5rem;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    .card-title {
+      font-family: var(--font-family-serif);
+      font-size: 1rem;
+      font-weight: 600;
+      line-height: 1.4;
+      margin: 0;
+      color: var(--text-primary);
+    }
+
+    .card-subtitle {
+      margin-top: 0.5rem;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    @media (max-width: 600px) {
+      .data-grid {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+      }
+
+      h1 {
+        font-size: 2rem;
+      }
+    }
+
+    .pagination {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 0;
+    }
+
+    .next-button {
+      color: var(--text-secondary);
+      transition: all 0.2s ease;
+      font-family: var(--font-family-sans);
+      font-size: 1.2em;
+      font-weight: 700;
+      text-decoration: none;
+      box-shadow: inset 0 -0.12em 0 var(--primary-color);
+      margin-left: auto;
+      -webkit-transition:
+        box-shadow 0.2s ease-in-out,
+        color 0.2s ease-in-out;
+      transition:
+        box-shadow 0.2s ease-in-out,
+        color 0.2s ease-in-out;
+    }
+
+    .next-button:hover {
+      color: var(--primary-color);
+      box-shadow: inset 0 -1.5em 0 var(--primary-color);
+      color: #fff;
+    }
+  </style>
+</BaseLayout>


### PR DESCRIPTION
Implemented pagination for the `/data` page, displaying 10 items per page.
- Moved `src/pages/data.astro` to `src/pages/data/index.astro`.
- Created `src/pages/data/[page].astro` for paginated routes.
- Retained styling and added pagination controls.
- Verified frontend functionality.

---
*PR created automatically by Jules for task [3989284282017192580](https://jules.google.com/task/3989284282017192580) started by @alharkan7*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly static UI/routing changes for a single page, with low blast radius; main risk is broken links/SEO due to route and pagination logic changes.
> 
> **Overview**
> Implements pagination for the `/data` listing by limiting the main page to 10 projects and adding navigation to subsequent pages.
> 
> Adds a new prerendered dynamic route `src/pages/data/[page].astro` that uses `getStaticPaths` to generate paginated pages from `featuredProjects`, including Prev/Next links, and updates `src/pages/data/index.astro` to show only the first slice plus a Next link when multiple pages exist. Also adds `astro_dev.log` to the repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0aac95589ba94154163b16bd75ed2233e5d7bb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->