### PR TITLE
Add home icon to national budget tabs

### DIFF
--- a/public/components/national-budget/script.js
+++ b/public/components/national-budget/script.js
@@ -158,10 +158,10 @@ function processData(rawData) {
 }
 
 function setupTabs() {
-    const tabs = document.querySelectorAll('.tab-btn');
+    const tabs = document.querySelectorAll('button.tab-btn');
     tabs.forEach(tab => {
         tab.addEventListener('click', () => {
-            document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+            document.querySelectorAll('button.tab-btn').forEach(b => b.classList.remove('active'));
             document.querySelectorAll('.tab-pane').forEach(c => c.classList.remove('active'));
             
             tab.classList.add('active');

--- a/public/components/national-budget/style.css
+++ b/public/components/national-budget/style.css
@@ -105,6 +105,18 @@ body {
     color: white;
 }
 
+.tab-home {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 10px;
+    text-decoration: none;
+}
+
+.tab-home svg {
+    display: block;
+}
+
 /* Header Controls */
 .header-controls {
     display: flex;
@@ -536,6 +548,12 @@ body {
         white-space: nowrap; /* Prevent tab text wrap */
         width: 100%; /* Ensure width is respected in flex */
         min-width: 0; /* Allow shrinking below content size if needed */
+    }
+
+    .tab-home {
+        flex: 0 0 auto;
+        width: auto;
+        padding: 8px 12px;
     }
     
     .header-controls {

--- a/src/featured/national-budget.html
+++ b/src/featured/national-budget.html
@@ -20,6 +20,12 @@
             </div>
             
             <nav class="tab-navigation">
+                <a href="/data" class="tab-btn tab-home" aria-label="Back to Data" title="Back to Data">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                        <polyline points="9 22 9 12 15 12 15 22"></polyline>
+                    </svg>
+                </a>
                 <button class="tab-btn active" data-tab="main-view">
                     <span class="desktop-text">Composition</span>
                     <span class="mobile-text">Mix</span>


### PR DESCRIPTION
This change adds a home icon link to the tab navigation on the `/national-budget` page, linking to `/data`.
It ensures correct layout on both desktop and mobile, with the home icon being square-ish and left-aligned.
The tab switching logic was updated to ignore the new link element.

---
*PR created automatically by Jules for task [17417377626787256239](https://jules.google.com/task/17417377626787256239) started by @alharkan7*