### PR TITLE
Fix mobile legend visibility on national-budget page

### DIFF
--- a/public/components/national-budget/script.js
+++ b/public/components/national-budget/script.js
@@ -175,14 +175,17 @@ function setupTabs() {
             const timelineControls = document.getElementById('timeline-controls');
             const filterControls = document.getElementById('filter-controls');
             const playBtn = document.getElementById('play-year-btn');
+            const mobileToggles = document.getElementById('mobile-toggles');
             
             if (state.activeTab === 'main-view') {
                 timelineControls.classList.remove('hidden');
                 filterControls.classList.add('hidden');
+                if (mobileToggles) mobileToggles.classList.remove('hidden');
                 // playBtn visibility is handled by renderMainChart
             } else {
                 timelineControls.classList.add('hidden');
                 filterControls.classList.remove('hidden');
+                if (mobileToggles) mobileToggles.classList.add('hidden');
                 if (playBtn) playBtn.style.display = 'none';
             }
             


### PR DESCRIPTION
- Modified `public/components/national-budget/script.js` to toggle the `hidden` class on `#mobile-toggles` element based on the active tab.
- Verified that the legend toggle is visible on 'main-view' and hidden on 'mixed-view' and 'area-view'.
- Verified that hiding the toggle allows the filter dropdown to expand on mobile.

---
*PR created automatically by Jules for task [8982058926071018723](https://jules.google.com/task/8982058926071018723) started by @alharkan7*