### PR TITLE
feat: sync URL params with filters on stars page

### DIFF
--- a/src/pages/stars.astro
+++ b/src/pages/stars.astro
@@ -744,6 +744,17 @@ const totalStars = starredRepos.length;
         const urlParams = new URLSearchParams(window.location.search);
         let currentPage = parseInt(urlParams.get("page") || "1", 10);
 
+        // Initialize filters from URL parameters
+        const initialCategory = urlParams.get("category");
+        if (initialCategory && categorySelect) {
+            categorySelect.value = initialCategory;
+        }
+
+        const initialSearch = urlParams.get("search");
+        if (initialSearch && searchInput) {
+            searchInput.value = initialSearch;
+        }
+
         let searchDebounce: ReturnType<typeof setTimeout> | null = null;
 
         function getFilterQuery(): string {
@@ -827,6 +838,21 @@ const totalStars = starredRepos.length;
         function updateUrl() {
             const url = new URL(window.location.href);
             url.searchParams.set("page", currentPage.toString());
+
+            const cat = getFilterCategory();
+            if (cat) {
+                url.searchParams.set("category", cat);
+            } else {
+                url.searchParams.delete("category");
+            }
+
+            const query = getFilterQuery();
+            if (query) {
+                url.searchParams.set("search", query);
+            } else {
+                url.searchParams.delete("search");
+            }
+
             if (url.toString() !== window.location.href) {
                 history.pushState({ page: currentPage }, "", url.toString());
             }
@@ -906,6 +932,21 @@ const totalStars = starredRepos.length;
 
         const initialUrl = new URL(window.location.href);
         initialUrl.searchParams.set("page", currentPage.toString());
+
+        const initialCat = getFilterCategory();
+        if (initialCat) {
+            initialUrl.searchParams.set("category", initialCat);
+        } else {
+            initialUrl.searchParams.delete("category");
+        }
+
+        const initialQ = getFilterQuery();
+        if (initialQ) {
+            initialUrl.searchParams.set("search", initialQ);
+        } else {
+            initialUrl.searchParams.delete("search");
+        }
+
         if (initialUrl.toString() !== window.location.href) {
             history.replaceState(
                 { page: currentPage },


### PR DESCRIPTION
Added URL parameter syncing for `category` and `search` filters on the stars page, allowing users to share specific filtered views via URL.

---
*PR created automatically by Jules for task [15663939823020356883](https://jules.google.com/task/15663939823020356883) started by @alharkan7*