### PR TITLE
Fix mobile layout for /likes page search and filter toolbar

### DIFF
--- a/src/pages/likes.astro
+++ b/src/pages/likes.astro
@@ -273,7 +273,7 @@ const initialBookmarkCount = likedTweets.filter((t) => t.is_bookmark).length;
     .likes-toolbar {
         display: flex;
         flex-wrap: nowrap;
-        align-items: center;
+        align-items: stretch;
         gap: 1rem;
         margin-block: 1.25rem 0.5rem;
     }
@@ -281,11 +281,13 @@ const initialBookmarkCount = likedTweets.filter((t) => t.is_bookmark).length;
     .likes-toolbar-field {
         min-width: 0;
         flex: 1;
+        display: flex;
     }
 
     .likes-search-wrap {
         position: relative;
-        display: block;
+        display: flex;
+        flex: 1;
     }
 
     .likes-filter-toggles {
@@ -293,13 +295,14 @@ const initialBookmarkCount = likedTweets.filter((t) => t.is_bookmark).length;
         gap: 0.5rem;
         margin-left: auto;
         flex-shrink: 0;
+        align-items: stretch;
     }
 
     .filter-toggle {
         display: flex;
         align-items: center;
         gap: 0.35rem;
-        padding: 0.4rem 0.75rem;
+        padding: 0 0.75rem;
         border: 1px solid var(--border-color);
         border-radius: 6px;
         background-color: var(--background-body);

--- a/src/pages/likes.astro
+++ b/src/pages/likes.astro
@@ -272,15 +272,15 @@ const initialBookmarkCount = likedTweets.filter((t) => t.is_bookmark).length;
 
     .likes-toolbar {
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         align-items: center;
-        gap: 1rem 1.5rem;
+        gap: 1rem;
         margin-block: 1.25rem 0.5rem;
     }
 
     .likes-toolbar-field {
-        min-width: min(100%, 300px);
-        flex: 1 1 300px;
+        min-width: 0;
+        flex: 1;
     }
 
     .likes-search-wrap {
@@ -292,6 +292,7 @@ const initialBookmarkCount = likedTweets.filter((t) => t.is_bookmark).length;
         display: flex;
         gap: 0.5rem;
         margin-left: auto;
+        flex-shrink: 0;
     }
 
     .filter-toggle {


### PR DESCRIPTION
Fixes the layout issue on the `/likes` page where the filter buttons wrapped to a new line below the search bar on mobile screens.

1. Updated `.likes-toolbar` to `flex-wrap: nowrap`.
2. Added `min-width: 0` to `.likes-toolbar-field` to let it shrink instead of wrapping.
3. Added `flex-shrink: 0` to `.likes-filter-toggles` to prevent the buttons from shrinking.

---
*PR created automatically by Jules for task [16671825003646378853](https://jules.google.com/task/16671825003646378853) started by @alharkan7*