### PR TITLE
tweets: label URL-only tweet cards as X Article

### DIFF
--- a/src/components/tweets/TweetsPage.astro
+++ b/src/components/tweets/TweetsPage.astro
@@ -17,6 +17,16 @@ function colorizeUrls(text: string): string {
   );
 }
 
+/** Posts that are only a link (e.g. shared articles) read better with a short label. */
+function labelUrlOnlyTweet(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return text;
+  if (/^https?:\/\/\S+$/.test(trimmed)) {
+    return `X Article: ${trimmed}`;
+  }
+  return text;
+}
+
 const title = "Saved Tweets";
 const description =
   "A curated list of liked, bookmarked, and retweeted posts from Twitter.";
@@ -175,6 +185,8 @@ const description =
               retweetUser = rtMatch[1];
               displayText = displayText.replace(rtMatch[0], "");
             }
+
+            displayText = labelUrlOnlyTweet(displayText);
 
             const viewUrl = `https://x.com/i/web/status/${tweet.id}`;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tweet cards whose body is only a single URL (common for shared articles) now show **"X Article: "** before the link so the card reads clearly instead of looking like a bare `t.co` string.

## Implementation

- After stripping the `RT @user:` prefix for display, if the remaining text is exactly one `http(s)` URL (trimmed), prepend `X Article: `.
- Existing URL styling (`colorizeUrls`) still applies to the URL portion.

## Testing

Build was not run in this environment (Node/pnpm unavailable). Please run `pnpm build` locally if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a63b0a3c-2c0a-44ef-8fa1-043aa4ac87f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a63b0a3c-2c0a-44ef-8fa1-043aa4ac87f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

