### PR TITLE
fix(tweets): canonical X status URLs for reliable native app opens

### DIFF
--- a/src/components/tweets/TweetsPage.astro
+++ b/src/components/tweets/TweetsPage.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import TweetIcons from "../../components/tweets/TweetIcons.astro";
-import type { TweetsViewModel } from "../../lib/tweets-query";
+import { tweetPublicUrl, type TweetsViewModel } from "../../lib/tweets-query";
 
 interface Props {
   view: TweetsViewModel;
@@ -188,7 +188,7 @@ const description =
 
             displayText = labelUrlOnlyTweet(displayText);
 
-            const viewUrl = `https://x.com/i/web/status/${tweet.id}`;
+            const viewUrl = tweetPublicUrl(tweet.id);
 
             return (
               <a

--- a/src/lib/tweets-query.ts
+++ b/src/lib/tweets-query.ts
@@ -20,6 +20,16 @@ const HIDDEN_SUBSTR =
 
 export const TWEETS_PAGE_SIZE = 30;
 
+/**
+ * Public tweet permalink for links and JSON-LD.
+ * Avoid `/i/web/status/{id}` — mobile/X apps often mishandle that path when opening
+ * from an external site; X resolves `/username/status/{id}` by tweet id and ignores a
+ * placeholder username (see X developer blog on canonical tweet URLs).
+ */
+export function tweetPublicUrl(tweetId: string): string {
+  return `https://x.com/twitter/status/${tweetId}`;
+}
+
 export function createTweetsSupabase(): SupabaseClient | null {
   const supabaseUrl = import.meta.env.SUPABASE_URL;
   const supabaseAnonKey = import.meta.env.SUPABASE_ANON_KEY;
@@ -143,7 +153,7 @@ export async function getStructuredTweetItems(
     name:
       (tweet.text || "").substring(0, 100) +
       ((tweet.text || "").length > 100 ? "..." : ""),
-    url: `https://twitter.com/i/web/status/${tweet.id}`,
+    url: tweetPublicUrl(tweet.id),
   }));
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tweet cards on `/tweets` linked to `https://x.com/i/web/status/{id}`. That pattern is the web-app permalink; some native Twitter/X clients mishandle it when invoked from an external site (open attempt cancelled / fallback), while opening the same tweet via a normal status URL works.

## Changes

- Introduce `tweetPublicUrl()` in `src/lib/tweets-query.ts` returning `https://x.com/twitter/status/{id}`. X resolves posts by tweet ID and redirects to the correct username; the literal `twitter` segment is a stable placeholder (same trick documented by X for tweet URLs when you only have an ID).
- Use it for tweet card `href`s and for JSON-LD item URLs.

## Testing

Not run in this environment (Node/pnpm unavailable). Please verify on a device where the native X app opens links.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b339785-3e14-4b2a-a984-7c599f3961fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b339785-3e14-4b2a-a984-7c599f3961fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

